### PR TITLE
fix: query param failing if they are not string

### DIFF
--- a/src/middleware/oas-validator.js
+++ b/src/middleware/oas-validator.js
@@ -317,7 +317,12 @@ function convertArrayValue(value, schema) {
     }
   }
 
-  return arrayValue.map(value, (item, index) => {
+  // Handle situation where value is not string type
+  if (!arrayValue && typeof value === "object") {
+    arrayValue = value;
+  }
+
+  return arrayValue.map((item, index) => {
     const itemSchema = Array.isArray(schema.items)
       ? schema.items[index]
       : schema.items;

--- a/tests/basic.mjs
+++ b/tests/basic.mjs
@@ -320,6 +320,22 @@ function getTests() {
         });
     });
 
+    it("it should return a 200 if an array of strings is defined duplicating param", (done) => {
+      chai
+        .request(server)
+        .get(
+          "/api/v1/arrayWithStringsTest?listTestParam=6363&listTestParam=6364"
+        )
+        .set("Authorization", "Bearer " + token)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          }
+          res.should.have.status(200);
+          done();
+        });
+    });
+
     it("it should get a 403 error because the user role does not have access", (done) => {
       chai
         .request(server)


### PR DESCRIPTION
## Dependencies

- express: 4.18.1
- oas-tools: 2.2.2
- node: v14.17.1
- npm: 6.14.13

## Explanation

Executing a petition where query params are defined as arrays (?testIds=32&testIds=33) returns the following error (version 2.2.2):
```bash
Cannot read property 'map' of undefined
```
Example:
```bash
localhost/test/type/small?testIds=32&testIds=33
```

This petition works with version 2.1.8. Seems like there was a modification on the code begining in 2.2.x which causes the error.

This pull request tries to resolve the issue adding a new conditional appending the value information to the parameter which is being processed in the map.

#### Version 2.2.2
```typescript
function convertArrayValue(value, schema) {
  let arrayValue;

  if (typeof value === "string") {
    try {
      arrayValue = JSON.parse(value); // Handle situation where the expected type is array but only one value was provided

      if (Array.isArray(arrayValue) === false) {
        return [value];
      }
    } catch (err) {
      return value;
    }
  }

  return arrayValue.map(value, (item, index) => {
    const itemSchema = Array.isArray(schema.items) ? schema.items[index] : schema.items;
    return convertValue(item, itemSchema, itemSchema ? itemSchema.type : undefined);
  });
}
```
#### Version 2.1.8
```typescript
  switch (type) {
    case 'array':
      if (_.isString(value)) {
          try {
            value = JSON.parse(value); // eslint-disable-line
          if (!_.isArray(value)) {
            value = original; // eslint-disable-line
          }
          } catch (err) {
            value = original; // eslint-disable-line
          }
      }

      // Handle situation where the expected type is array but only one value was provided
      if (!_.isArray(value)) {
        value = [value]; // eslint-disable-line
      }

      value = _.map(value, function(item, index) { // eslint-disable-line
        var iSchema = _.isArray(schema.items) ? schema.items[index] : schema.items;

        return convertValue(item, iSchema, iSchema ? iSchema.type : undefined);
      });

      break;
```
swagger.json example
```json
get:
      operationId: getTest
      x-router-controller: test
      parameters:
        - name: type
          in: path
          description: 'test's type'
          required: true
          style: simple
          explode: false
          schema:
            maxItems: 1
            type: string
            pattern: ^(small|medium|large)$
        - name: testIds
          in: query
          required: false
          description: Test identifiers separated by commas.
          schema:
            minItems: 1
            type: array
            items:
              type: string
```
